### PR TITLE
Wwise: show project supported platforms as "Available Platforms" in "Generate Sound Banks" window

### DIFF
--- a/Wwise/Source/AudiokineticTools/AudiokineticTools.Build.cs
+++ b/Wwise/Source/AudiokineticTools/AudiokineticTools.Build.cs
@@ -40,6 +40,7 @@ public class AudiokineticTools : ModuleRules
 				"XmlParser",
 				"WorkspaceMenuStructure",
 				"DirectoryWatcher",
+                "Projects",
                 "PropertyEditor"
             });
 

--- a/Wwise/Source/AudiokineticTools/Private/SGenerateSoundBanks.h
+++ b/Wwise/Source/AudiokineticTools/Private/SGenerateSoundBanks.h
@@ -36,6 +36,7 @@ private:
 	TSharedRef<ITableRow> MakeBankListItemWidget(TSharedPtr<FString> Bank, const TSharedRef<STableViewBase>& OwnerTable);
 	TSharedRef<ITableRow> MakePlatformListItemWidget(TSharedPtr<FString> Platform, const TSharedRef<STableViewBase>& OwnerTable);
 	void GetWwisePlatforms();
+	void AddPlatformIfSupported(const TSet<FString>& SupportedPlatforms, const FString& UnrealName, const TCHAR* WwiseName);
 	bool FetchAttenuationInfo(const TMap<FString, TSet<UAkAudioEvent*> >& BankToEventSet);
 
 private:


### PR DESCRIPTION
Before this change Wwise allow to generate sound banks for platforms which Editor can cook in this enviroment. In this case Sound Enginee should install Android SDK, Linux Toolchain only for generating sound banks.

After this change Wwise allow to generate sound banks for game supported platforms.