### PR TITLE
Bank load/unload reworked.

### DIFF
--- a/Source/AkAudio/Classes/AkAudioBank.h
+++ b/Source/AkAudio/Classes/AkAudioBank.h
@@ -4,7 +4,10 @@
 	AkBank.h:
 =============================================================================*/
 #pragma once
+#include "AkInclude.h"
 #include "AkAudioBank.generated.h"
+
+DECLARE_DELEGATE_OneParam(FAkAudioBankDelegate, AKRESULT);
 
 /*------------------------------------------------------------------------------------
 	UAkAudioBank
@@ -73,11 +76,10 @@ public:
 	/**
 	 * Loads an AkBank asynchronously.
 	 *
-	 * @param in_pfnBankCallback		Function to call on completion
-	 * @param in_pCookie				Cookie to pass in callback
+	 * @param CompleteHandle Callback delegate
 	 * @return Returns true if the laod was successful, otherwise false
 	 */
-	bool LoadAsync(void* in_pfnBankCallback, void* in_pCookie);
+	bool LoadAsync(FAkAudioBankDelegate CompleteHandle);
 	
 	/**
 	 * Unloads an AkBank.
@@ -87,9 +89,8 @@ public:
 	/**
 	 * Unloads an AkBank asynchronously.
 	 *
-	 * @param in_pfnBankCallback		Function to call on completion
-	 * @param in_pCookie				Cookie to pass in callback
+	 * @param CompleteHandle Callback delegate
 	 */
-	void UnloadAsync(void* in_pfnBankCallback, void* in_pCookie);
+	void UnloadAsync(FAkAudioBankDelegate CompleteHandle);
 #endif
 };

--- a/Source/AkAudio/Classes/AkAudioBankCallbackProxy.h
+++ b/Source/AkAudio/Classes/AkAudioBankCallbackProxy.h
@@ -1,0 +1,39 @@
+/*=============================================================================
+	AkAudioBankCallbackProxy.h 
+=============================================================================*/
+#pragma once
+#include "Kismet/BlueprintAsyncActionBase.h"
+#include "AkAudioBankCallbackProxy.generated.h"
+
+DECLARE_DYNAMIC_MULTICAST_DELEGATE(FAkAdioBankCompleteDelegate);
+
+UCLASS()
+class AKAUDIO_API UAkAudioBankCallbackProxy : public UBlueprintAsyncActionBase
+{
+	GENERATED_UCLASS_BODY() 
+
+private:
+	AKRESULT Result = AK_Fail;
+
+	bool bCompleted = false;
+
+public:
+	// Called when there is a successful query
+	UPROPERTY(BlueprintAssignable)
+	FAkAdioBankCompleteDelegate OnSuccess;
+
+	// Called when there is an unsuccessful query
+	UPROPERTY(BlueprintAssignable)
+	FAkAdioBankCompleteDelegate OnFailure;
+
+	// UBlueprintAsyncActionBase interface
+	virtual void Activate() override;
+	// End of UBlueprintAsyncActionBase interface
+
+	void Complete(AKRESULT InResult);
+
+public:
+	// Joins a remote session with the default online subsystem
+	UFUNCTION(BlueprintCallable, meta = (BlueprintInternalUseOnly = "true"), Category = "Audiokinetic|SoundBanks")
+	static UAkAudioBankCallbackProxy* LoadBankAsync(class UAkAudioBank* Bank);
+};

--- a/Source/AkAudio/Private/AkAudioBank.cpp
+++ b/Source/AkAudio/Private/AkAudioBank.cpp
@@ -35,10 +35,7 @@ void UAkAudioBank::PostLoad()
  */
 void UAkAudioBank::BeginDestroy()
 {
-	if( AutoLoad )
-	{
-		Unload();
-	}
+	Unload();
 	Super::BeginDestroy();
 }
 
@@ -70,7 +67,7 @@ bool UAkAudioBank::Load()
  * @param in_pCookie				Cookie to pass in callback
  * @return Returns true if the laod was successful, otherwise false
  */
-bool UAkAudioBank::LoadAsync(void* in_pfnBankCallback, void* in_pCookie)
+bool UAkAudioBank::LoadAsync(FAkAudioBankDelegate CompleteHandle)
 {
 	if( !IsRunningCommandlet() )
 	{
@@ -78,7 +75,7 @@ bool UAkAudioBank::LoadAsync(void* in_pfnBankCallback, void* in_pCookie)
 		if( AudioDevice )
 		{
 			AkBankID BankID;
-			AKRESULT eResult = AudioDevice->LoadBank( this, (AkBankCallbackFunc)in_pfnBankCallback, in_pCookie, AK_DEFAULT_POOL_ID, BankID );
+			AKRESULT eResult = AudioDevice->LoadBank(this, CompleteHandle, AK_DEFAULT_POOL_ID, BankID);
 			return (eResult == AK_Success) ? true : false;
 		}
 	}
@@ -107,7 +104,7 @@ void UAkAudioBank::Unload()
  * @param in_pfnBankCallback		Function to call on completion
  * @param in_pCookie				Cookie to pass in callback
  */
-void UAkAudioBank::UnloadAsync(void* in_pfnBankCallback, void* in_pCookie)
+void UAkAudioBank::UnloadAsync(FAkAudioBankDelegate CompleteHandle)
 {
 	if( !IsRunningCommandlet() )
 	{
@@ -115,7 +112,7 @@ void UAkAudioBank::UnloadAsync(void* in_pfnBankCallback, void* in_pCookie)
 		FAkAudioDevice * AudioDevice = FAkAudioDevice::Get();
 		if( AudioDevice )
 		{
-			eResult = AudioDevice->UnloadBank( this, (AkBankCallbackFunc)in_pfnBankCallback, in_pCookie );
+			eResult = AudioDevice->UnloadBank(this, CompleteHandle);
 		}
 	}
 }

--- a/Source/AkAudio/Private/AkAudioBankCallbackProxy.cpp
+++ b/Source/AkAudio/Private/AkAudioBankCallbackProxy.cpp
@@ -1,0 +1,50 @@
+/*=============================================================================
+	AkAudioBankCallbackProxy.cpp:
+=============================================================================*/
+
+#include "AkAudioDevice.h"
+#include "AkAudioBankCallbackProxy.h"
+
+UAkAudioBankCallbackProxy::UAkAudioBankCallbackProxy(const FObjectInitializer &Initilizer)
+	: Super(Initilizer)
+{
+}
+
+UAkAudioBankCallbackProxy* UAkAudioBankCallbackProxy::LoadBankAsync(class UAkAudioBank* Bank)
+{
+	UAkAudioBankCallbackProxy* Result = NewObject<UAkAudioBankCallbackProxy>();
+	if (Bank && Bank->LoadAsync(FAkAudioBankDelegate::CreateUObject(Result, &UAkAudioBankCallbackProxy::Complete)))
+	{
+		return Result;
+	}
+	Result->Complete(AK_Fail);
+	return Result;
+}
+
+void UAkAudioBankCallbackProxy::Activate()
+{
+	if (bCompleted)
+	{
+		if (Result == AK_Success)
+		{
+			OnSuccess.Broadcast();
+		}
+		else
+		{
+			OnFailure.Broadcast();
+		}
+		OnSuccess.Clear();
+		OnFailure.Clear();
+	}
+}
+
+void UAkAudioBankCallbackProxy::Complete(AKRESULT InResult)
+{
+	if (!bCompleted)
+	{
+		Result = InResult;
+		bCompleted = true;
+
+		Activate();
+	}
+}

--- a/Source/AkAudio/Private/AkBankManager.cpp
+++ b/Source/AkAudio/Private/AkBankManager.cpp
@@ -1,0 +1,212 @@
+// Copyright (c) 2006-2012 Audiokinetic Inc. / All Rights Reserved
+
+/*=============================================================================
+	AkBank.cpp:
+=============================================================================*/
+
+#include "AkAudioDevice.h"
+#include "AkBankManager.h"
+
+volatile size_t FAkBankManager::m_CallbackId = 0;
+
+void FAkBankManager::Update()
+{
+	if (m_BankCallbackMap.Num() == 0)
+	{
+		if (m_UnloadBanks.Num())
+		{
+			TSet<FString> UnloadBanksCopy(m_UnloadBanks);
+			for (const FString& BankName : UnloadBanksCopy)
+			{
+				ForceUnloadBank(BankName, nullptr);
+			}
+		}
+	}
+}
+
+AKRESULT FAkBankManager::LoadBank(
+	const FString& in_BankName,
+	AkMemPoolId    in_memPoolId,
+	AkBankID&      out_bankID
+	)
+{
+	{
+		FScopeLock Lock(&m_BankManagerCriticalSection);
+		if (m_LoadedBanks.Contains(in_BankName))
+		{
+			m_UnloadBanks.Remove(in_BankName);
+			return AK_Success;
+		}
+	}
+
+#ifndef AK_SUPPORT_WCHAR
+	const ANSICHAR* szString = TCHAR_TO_ANSI(*in_BankName);
+#else
+	const WIDECHAR* szString = *in_BankName;
+#endif		
+	AKRESULT eResult = AK::SoundEngine::LoadBank( szString, in_memPoolId, out_bankID );
+	if (eResult == AK_Success)
+	{
+		FScopeLock Lock(&m_BankManagerCriticalSection);
+		bool bIsAlreadyInSet = false;
+		m_LoadedBanks.Add(in_BankName, &bIsAlreadyInSet);
+		check(bIsAlreadyInSet == false);
+	}
+	return eResult;
+}
+
+void FAkBankManager::BankLoadCallback(
+	AkUInt32		in_bankID,
+	const void *	in_pInMemoryBankPtr,
+	AKRESULT		in_eLoadResult,
+	AkMemPoolId		in_memPoolId,
+	void *			in_pCookie
+	)
+{
+	if (FAkAudioDevice* akAudioDevice = FAkAudioDevice::Get())
+	{
+		FAkAudioBankDelegate CallbackFunc;
+		if (FAkBankManager* BankManager = akAudioDevice->GetAkBankManager())
+		{
+			FScopeLock Lock(&BankManager->m_BankManagerCriticalSection);
+			AkBankCallbackInfo cbInfo;
+			if (BankManager->m_BankCallbackMap.RemoveAndCopyValue(in_pCookie, cbInfo))
+			{
+				if (in_eLoadResult == AK_Success)
+				{
+					BankManager->m_LoadedBanks.Add(cbInfo.BankName);
+				}
+				CallbackFunc = cbInfo.CallbackFunc;
+			}
+		}
+		CallbackFunc.ExecuteIfBound(in_eLoadResult);
+	}
+}
+
+AKRESULT FAkBankManager::LoadBankAsync(
+	const FString&       in_BankName,
+	FAkAudioBankDelegate in_Handle,
+	AkMemPoolId          in_memPoolId,
+	AkBankID&            out_bankID
+	)
+{
+	size_t CallbackId;
+	{
+		FScopeLock Lock(&m_BankManagerCriticalSection);
+		if (m_LoadedBanks.Contains(in_BankName))
+		{
+			m_UnloadBanks.Remove(in_BankName);
+			in_Handle.ExecuteIfBound(AK_Success);
+			return AK_Success;
+		}
+		// Need to hijack the callback, so we can add the bank to the loaded banks list when successful.
+		CallbackId = ++m_CallbackId;
+		m_BankCallbackMap.Add((void*)CallbackId, AkBankCallbackInfo(in_Handle, in_BankName));
+	}
+#ifndef AK_SUPPORT_WCHAR
+	const ANSICHAR* szString = TCHAR_TO_ANSI(*in_BankName);
+#else
+	const WIDECHAR* szString = *in_BankName;
+#endif
+	return AK::SoundEngine::LoadBank(szString, &BankLoadCallback, (void*)CallbackId, in_memPoolId, out_bankID);
+}
+
+AKRESULT FAkBankManager::UnloadBank(
+	const FString&      in_BankName,
+	AkMemPoolId *       out_pMemPoolId
+	)
+{
+	{
+		FScopeLock Lock(&m_BankManagerCriticalSection);
+		m_UnloadBanks.Add(in_BankName);
+		if (!m_LoadedBanks.Contains(in_BankName))
+		{
+			return AK_Success;
+		}
+
+		if (!out_pMemPoolId)
+		{
+			m_UnloadBanks.Add(in_BankName);
+			return AK_Success;
+		}
+	}
+	return ForceUnloadBank(in_BankName, out_pMemPoolId);
+}
+
+void FAkBankManager::BankUnloadCallback(
+	AkUInt32		in_bankID,
+	const void *	in_pInMemoryBankPtr,
+	AKRESULT		in_eUnloadResult,
+	AkMemPoolId		in_memPoolId,
+	void *			in_pCookie
+	)
+{
+	if (FAkAudioDevice* akAudioDevice = FAkAudioDevice::Get())
+	{
+		FAkAudioBankDelegate CallbackFunc;
+		if (FAkBankManager* BankManager = akAudioDevice->GetAkBankManager())
+		{
+			FScopeLock Lock(&BankManager->m_BankManagerCriticalSection);
+
+			AkBankCallbackInfo cbInfo;
+			if (BankManager->m_BankCallbackMap.RemoveAndCopyValue(in_pCookie, cbInfo))
+			{
+				if (in_eUnloadResult == AK_Success)
+				{
+					BankManager->m_LoadedBanks.Remove(cbInfo.BankName);
+					BankManager->m_UnloadBanks.Remove(cbInfo.BankName);
+				}
+				CallbackFunc = cbInfo.CallbackFunc;
+			}
+		}
+		CallbackFunc.ExecuteIfBound(in_eUnloadResult);
+	}
+}
+
+AKRESULT FAkBankManager::UnloadBankAsync(
+	const FString&       in_BankName,
+	FAkAudioBankDelegate in_Handle
+	)
+{
+#ifndef AK_SUPPORT_WCHAR
+	const ANSICHAR* szString = TCHAR_TO_ANSI(*in_BankName);
+#else
+	const WIDECHAR* szString = *in_BankName;
+#endif
+
+	// Need to hijack the callback, so we can add the bank to the loaded banks list when successful.
+	size_t CallbackId;
+	{
+		FScopeLock Lock(&m_BankManagerCriticalSection);
+		CallbackId = ++m_CallbackId;
+		m_BankCallbackMap.Add((void*)CallbackId, AkBankCallbackInfo(in_Handle, in_BankName));
+	}
+	return AK::SoundEngine::UnloadBank(szString, nullptr, &BankUnloadCallback, (void*)CallbackId);
+}
+
+AKRESULT FAkBankManager::ForceUnloadBank(
+	const FString&      in_BankName,
+	AkMemPoolId *       out_pMemPoolId
+	)
+{
+	AKRESULT eResult = AK_Fail;
+	bool bLoaded = false;
+	{
+		FScopeLock Lock(&m_BankManagerCriticalSection);
+		m_UnloadBanks.Remove(in_BankName);
+		if (m_LoadedBanks.Remove(in_BankName))
+		{
+			bLoaded = true;
+		}
+	}
+	if (bLoaded)
+	{
+#ifndef AK_SUPPORT_WCHAR
+		const ANSICHAR* szString = TCHAR_TO_ANSI(*in_BankName);
+#else
+		const WIDECHAR* szString = *in_BankName;
+#endif
+		eResult = AK::SoundEngine::UnloadBank(szString, out_pMemPoolId);
+	}
+	return eResult;
+}

--- a/Source/AkAudio/Public/AkAudioDevice.h
+++ b/Source/AkAudio/Public/AkAudioDevice.h
@@ -13,6 +13,7 @@
 #include "Engine.h"
 
 #include "AkInclude.h"
+#include "AkAudioBank.h"
 #include "AkBankManager.h"
 #include "SoundDefinitions.h"
 
@@ -164,12 +165,11 @@ public:
 	 * @return Result from ak sound engine 
 	 */
 	AKRESULT LoadBank(
-        class UAkAudioBank *      in_Bank,
-		AkBankCallbackFunc  in_pfnBankCallback,
-		void *              in_pCookie,
-        AkMemPoolId         in_memPoolId,
+		class UAkAudioBank *      in_Bank,
+		FAkAudioBankDelegate CompleteHandle,
+		AkMemPoolId         in_memPoolId,
 		AkBankID &          out_bankID
-        );
+	);
 		
 	/**
 	 * Unload a soundbank
@@ -200,14 +200,12 @@ public:
 	 *
 	 * @param in_Bank			The bank to unload
 	 * @param in_pfnBankCallback Callback function
-	 * @param in_pCookie		Callback cookie (reserved to user, passed to the callback function)
 	 * @return Result from ak sound engine 
 	 */
 	AKRESULT UnloadBank(
-        class UAkAudioBank *      in_Bank,
-		AkBankCallbackFunc  in_pfnBankCallback,
-		void *              in_pCookie
-        );
+		class UAkAudioBank *      in_Bank,
+		FAkAudioBankDelegate CompleteHandle
+	);
 
 	/**
 	 * Load the audiokinetic 'init' bank


### PR DESCRIPTION
Changes:

 * Unload bank on the next tick for prevent load/unload same bank on level change;
 * Banks always scheduled to unload on level change (event AutoLoad = false), but if somebody try to load in on first level tick, bank should keep in memory;
 * Change Callback+Cookie by Delegate for LoadAsync/UnloadAsync (breaking change);
 * Add Blueprintable async node for bank loading;
 * Loading already loaded bank is not considered as error.

![image](https://cloud.githubusercontent.com/assets/2458138/15650130/1786b88a-267f-11e6-9801-2528e7f77b0d.png)
